### PR TITLE
fix: delete node editor issue for windows machine

### DIFF
--- a/src/pages/EditorPage/EditorPage.tsx
+++ b/src/pages/EditorPage/EditorPage.tsx
@@ -418,6 +418,7 @@ const EditorPage = () => {
             onInit={handleOnInit}
             onDrop={onDrop}
             onDragOver={onDragOver}
+            deleteKeyCode={['Delete', 'Backspace']}
             // this is to disable multi select
             multiSelectionKeyCode={null}>
             <WatermarkPanel hideWaterMark={hideWaterMark} />


### PR DESCRIPTION
# Description
So there is no support to delete a editor node while pressing delete key in windows machine so i have fix this issue in this PR

Fixes #72

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

