### PR TITLE
chore: reduce number of api calls in editor page

### DIFF
--- a/src/pages/EditorPage/EditorPage.tsx
+++ b/src/pages/EditorPage/EditorPage.tsx
@@ -24,8 +24,10 @@ import {
   getDragHandleByNodeType,
   getInitialNodeDataByType,
   getParsedValue,
+  getSnippetSnapshot,
   getStringifiedValue,
   getUniqueId,
+  isAllowedToUpdate,
 } from 'utils/EditorUtils';
 
 import WatermarkPanel from 'components/Editor/Panels/WatermarkPanel';
@@ -47,7 +49,6 @@ import {
   Snippet,
   SnippetData,
 } from 'interfaces/AppProvider.interface';
-import { toPng } from 'html-to-image';
 
 const EditorPage = () => {
   const toast = useToast();
@@ -131,40 +132,25 @@ const EditorPage = () => {
   };
 
   const handleUpdateSnippetSnapshot = async (snippetId: string) => {
-    const node = document.querySelector('.react-flow');
-    if (node) {
-      try {
-        const imageBase64Url = await toPng(node as HTMLElement, {
-          filter: (node) => {
-            // we don't want to add the minimap and the controls to the image
-            if (
-              node?.classList?.contains('react-flow__minimap') ||
-              node?.classList?.contains('react-flow__controls')
-            ) {
-              return false;
-            }
+    const imageBase64Url = await getSnippetSnapshot();
+    if (!imageBase64Url) return;
 
-            return true;
-          },
-          quality: 1,
-        });
-
-        await API_CLIENT.database.updateDocument(
-          DATABASE_ID,
-          COLLECTION_ID,
-          snippetId,
-          { cover_image_base64_url: imageBase64Url }
-        );
-      } catch (error) {
-        const exception = error as AppwriteException;
-        toast({
-          description: exception.message,
-          status: 'error',
-          duration: 9000,
-          isClosable: true,
-          position: 'top-right',
-        });
-      }
+    try {
+      await API_CLIENT.database.updateDocument(
+        DATABASE_ID,
+        COLLECTION_ID,
+        snippetId,
+        { cover_image_base64_url: imageBase64Url }
+      );
+    } catch (error) {
+      const exception = error as AppwriteException;
+      toast({
+        description: exception.message,
+        status: 'error',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-right',
+      });
     }
   };
 
@@ -179,7 +165,10 @@ const EditorPage = () => {
       handleSnippetDataInit(data);
       setIsLoading(false);
 
-      handleUpdateSnippetSnapshot(data.$id);
+      // if cover image is not available then update the cover image on initialization
+      if (!data.cover_image_base64_url) {
+        handleUpdateSnippetSnapshot(data.$id);
+      }
     } catch (error) {
       const exception = error as AppwriteException;
       toast({
@@ -194,14 +183,23 @@ const EditorPage = () => {
   };
 
   const updateSnippetData = async (updatedData: Partial<Snippet>) => {
-    if (snippetData?.$id) {
+    const imageBase64Url = await getSnippetSnapshot();
+    /**
+     * only update the snippet data if updated data is different from the existing data
+     * and snapshot image base64 url is available
+     */
+    if (
+      snippetData?.$id &&
+      isAllowedToUpdate(snippetData, updatedData) &&
+      imageBase64Url
+    ) {
       try {
         setIsUpdating(true);
         const data = await API_CLIENT.database.updateDocument<SnippetData>(
           DATABASE_ID,
           COLLECTION_ID,
           snippetData.$id,
-          updatedData
+          { ...updatedData, cover_image_base64_url: imageBase64Url }
         );
 
         setSnippetData(data);
@@ -373,18 +371,17 @@ const EditorPage = () => {
       }
     };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
+    // only add event listener if content is unsaved
+    if (isNeedUpdate) {
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    } else {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    }
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [isNeedUpdate]);
-
-  useEffect(() => {
-    if (!isNeedUpdate && snippetData) {
-      handleUpdateSnippetSnapshot(snippetData.$id);
-    }
-  }, [isNeedUpdate, snippetData]);
 
   if (isLoading) {
     return <Loader />;

--- a/src/utils/EditorUtils.ts
+++ b/src/utils/EditorUtils.ts
@@ -1,6 +1,9 @@
 import { INITIAL_CONTEXT_DATA } from 'constants/common';
 import { CUSTOM_NODES } from 'constants/editor';
+import { toPng } from 'html-to-image';
+import { Snippet, SnippetData } from 'interfaces/AppProvider.interface';
 import { NodeDataStore } from 'interfaces/Editor.interface';
+import { cloneDeep, isEqual } from 'lodash';
 import { v4 as generateUniqueId } from 'uuid';
 
 export const getDragHandleByNodeType = (type: string) => {
@@ -50,4 +53,41 @@ export const getStringifiedValue = (data: unknown) => {
 
 export const getParsedValue = (data: string) => {
   return JSON.parse(data);
+};
+
+export const getSnippetSnapshot = async () => {
+  const node = document.querySelector('.react-flow');
+  if (node) {
+    try {
+      const imageBase64Url = await toPng(node as HTMLElement, {
+        filter: (node) => {
+          // we don't want to add the minimap and the controls to the image
+          if (
+            node?.classList?.contains('react-flow__minimap') ||
+            node?.classList?.contains('react-flow__controls')
+          ) {
+            return false;
+          }
+
+          return true;
+        },
+        quality: 1,
+      });
+
+      return imageBase64Url;
+    } catch (error) {
+      return '';
+    }
+  }
+
+  return '';
+};
+
+export const isAllowedToUpdate = (
+  snippetData: SnippetData,
+  updatedData: Partial<Snippet>
+) => {
+  const clonedSnippetData = cloneDeep(snippetData);
+  const updatedSnippetData = { ...clonedSnippetData, ...updatedData };
+  return !isEqual(clonedSnippetData, updatedSnippetData);
 };


### PR DESCRIPTION
# Description

This PR aims to reduce the number of API calls made on the editor page:

1. An update API call will only be made if the updated data differs from the existing data.
2. A snapshot will be generated only on the first render if no existing snapshot is present.
3. The snapshot update call is now merged with the update snippet API call, eliminating the need for a separate call.


## Type of change

- [x] Improvements


# How Has This Been Tested?

1. Create a new snippet.
2. Redirect to the editor page.
3. Open the developer tools and monitor the network:
   - You should see one call to get snippet data.
   - If the snapshot is not present, there will be an additional call to update the snapshot.
   - No other calls should be made.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
