### PR TITLE
Improve empty state UI with a placeholder and create new snippet button

### DIFF
--- a/src/components/NoSnippets/NoSnippets.tsx
+++ b/src/components/NoSnippets/NoSnippets.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Text, VStack, Icon } from '@chakra-ui/react';
 import { FiFilePlus } from 'react-icons/fi';
 
-const NoSnippetsPage: React.FC = () => {
+const NoSnippets: React.FC = () => {
   return (
     <VStack spacing={6} minHeight="100vh" p={4}>
       <Icon as={FiFilePlus} boxSize={24} color="gray.400" />
       <Text fontSize="xl" fontWeight="semibold">
-        Oops! Looks like you&apos;re starting with a clean slate.
+        Looks like you&apos;re starting with a clean slate.
       </Text>
       <Text fontSize="lg" textAlign="center">
         No snippets have been created yet. Start by adding your first snippet
@@ -17,4 +17,4 @@ const NoSnippetsPage: React.FC = () => {
   );
 };
 
-export default NoSnippetsPage;
+export default NoSnippets;

--- a/src/components/SnippetList/SnippetList.tsx
+++ b/src/components/SnippetList/SnippetList.tsx
@@ -13,6 +13,7 @@ import {
   Skeleton,
   Stack,
   useToast,
+  GridItem,
 } from '@chakra-ui/react';
 import { useAppProvider } from 'AppProvider';
 import { API_CLIENT } from 'api';
@@ -37,6 +38,7 @@ import {
   SnippetData,
 } from 'interfaces/AppProvider.interface';
 import { map } from 'lodash';
+import NoSnippetsPage from 'pages/NoSnippetsPage/NoSnippetsPage';
 import React, { useEffect, useState } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { RxCopy } from 'react-icons/rx';
@@ -263,78 +265,84 @@ const SnippetList = () => {
           </>
         ) : (
           <>
-            {map(snippets?.documents, (snippet) => (
-              <AspectRatio
-                as={motion.div}
-                whileHover={{
-                  scale: 1.1,
-                }}
-                maxHeight="200px"
-                maxWidth="300px"
-                key={snippet.$id}
-                ratio={1}
-                borderRadius={BORDER_RADIUS_LARGE}>
-                <Button
-                  role="group"
-                  position="relative"
-                  bg="transparent"
-                  _hover={{ bg: 'transparent' }}
-                  onClick={() => {
-                    handleNavigate(snippet.$id);
-                  }}>
-                  <Stack
-                    zIndex={5}
-                    _groupHover={{ display: 'flex' }}
-                    position="absolute"
-                    direction="row"
-                    display={'none'}>
-                    <Button
-                      variant="ghost"
-                      color="white"
-                      _hover={{ color: 'gray.600', bg: 'gray.100' }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setDeleteId(snippet.$id);
-                      }}>
-                      <MdDelete />
-                    </Button>
-                    <Button
-                      isLoading={isDuplicating}
-                      variant="ghost"
-                      color="white"
-                      _hover={{ color: 'gray.600', bg: 'gray.100' }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        duplicateSnippet({
-                          background: snippet.background,
-                          hideWaterMark: snippet.hideWaterMark,
-                          profileInfo: snippet.profileInfo,
-                          nodes: snippet.nodes,
-                          creator: snippet.creator,
-                          snapshot: snippet.snapshot,
-                          cover_image_base64_url:
-                            snippet.cover_image_base64_url,
-                        });
-                      }}>
-                      <RxCopy />
-                    </Button>
-                  </Stack>
-                  <Image
-                    _groupHover={{ opacity: 0.8 }}
-                    borderRadius={BORDER_RADIUS_MEDIUM}
-                    src={
-                      snippet?.cover_image_base64_url ??
-                      API_CLIENT.storage.getFilePreview(
-                        BUCKET_ID,
-                        snippet.snapshot
-                      ).href
-                    }
-                  />
-                </Button>
-              </AspectRatio>
-            ))}
+            {snippets?.total === 0 ? (
+              <GridItem colSpan={4}>
+                <NoSnippetsPage />
+              </GridItem>
+            ) : (
+              map(snippets?.documents, (snippet) => (
+                <AspectRatio
+                  as={motion.div}
+                  whileHover={{
+                    scale: 1.1,
+                  }}
+                  maxHeight="200px"
+                  maxWidth="300px"
+                  key={snippet.$id}
+                  ratio={1}
+                  borderRadius={BORDER_RADIUS_LARGE}>
+                  <Button
+                    role="group"
+                    position="relative"
+                    bg="transparent"
+                    _hover={{ bg: 'transparent' }}
+                    onClick={() => {
+                      handleNavigate(snippet.$id);
+                    }}>
+                    <Stack
+                      zIndex={5}
+                      _groupHover={{ display: 'flex' }}
+                      position="absolute"
+                      direction="row"
+                      display={'none'}>
+                      <Button
+                        variant="ghost"
+                        color="white"
+                        _hover={{ color: 'gray.600', bg: 'gray.100' }}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setDeleteId(snippet.$id);
+                        }}>
+                        <MdDelete />
+                      </Button>
+                      <Button
+                        isLoading={isDuplicating}
+                        variant="ghost"
+                        color="white"
+                        _hover={{ color: 'gray.600', bg: 'gray.100' }}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          duplicateSnippet({
+                            background: snippet.background,
+                            hideWaterMark: snippet.hideWaterMark,
+                            profileInfo: snippet.profileInfo,
+                            nodes: snippet.nodes,
+                            creator: snippet.creator,
+                            snapshot: snippet.snapshot,
+                            cover_image_base64_url:
+                              snippet.cover_image_base64_url,
+                          });
+                        }}>
+                        <RxCopy />
+                      </Button>
+                    </Stack>
+                    <Image
+                      _groupHover={{ opacity: 0.8 }}
+                      borderRadius={BORDER_RADIUS_MEDIUM}
+                      src={
+                        snippet?.cover_image_base64_url ??
+                        API_CLIENT.storage.getFilePreview(
+                          BUCKET_ID,
+                          snippet.snapshot
+                        ).href
+                      }
+                    />
+                  </Button>
+                </AspectRatio>
+              ))
+            )}
           </>
         )}
       </Grid>

--- a/src/components/SnippetList/SnippetList.tsx
+++ b/src/components/SnippetList/SnippetList.tsx
@@ -19,6 +19,7 @@ import { useAppProvider } from 'AppProvider';
 import { API_CLIENT } from 'api';
 import { AppwriteException, Models, Query } from 'appwrite';
 import SpinnerLoader from 'components/Common/Loader/SpinnerLoader';
+import NoSnippets from 'components/NoSnippets/NoSnippets';
 import Pagination from 'components/Pagination/Pagination';
 import Sorting, { SORTING_OPTIONS } from 'components/Sorting/Sorting';
 import {
@@ -38,7 +39,6 @@ import {
   SnippetData,
 } from 'interfaces/AppProvider.interface';
 import { map } from 'lodash';
-import NoSnippetsPage from 'pages/NoSnippetsPage/NoSnippetsPage';
 import React, { useEffect, useState } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { RxCopy } from 'react-icons/rx';
@@ -267,7 +267,7 @@ const SnippetList = () => {
           <>
             {snippets?.total === 0 ? (
               <GridItem colSpan={4}>
-                <NoSnippetsPage />
+                <NoSnippets />
               </GridItem>
             ) : (
               map(snippets?.documents, (snippet) => (

--- a/src/pages/NoSnippetsPage/NoSnippetsPage.tsx
+++ b/src/pages/NoSnippetsPage/NoSnippetsPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Text, VStack, Icon } from '@chakra-ui/react';
+import { FiFilePlus } from 'react-icons/fi';
+
+const NoSnippetsPage: React.FC = () => {
+  return (
+    <VStack spacing={6} minHeight="100vh" p={4}>
+      <Icon as={FiFilePlus} boxSize={24} color="gray.400" />
+      <Text fontSize="xl" fontWeight="semibold">
+        Oops! Looks like you&apos;re starting with a clean slate.
+      </Text>
+      <Text fontSize="lg" textAlign="center">
+        No snippets have been created yet. Start by adding your first snippet
+        and let your creativity flow!
+      </Text>
+    </VStack>
+  );
+};
+
+export default NoSnippetsPage;


### PR DESCRIPTION
# Description

Enhanced the user experience on the dashboard page when no snippets are available. Instead of showing an empty page, a placeholder message indicates that no snippets have been created yet.

Fixes #96 

## Type of change

- [x] Enhancement (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested the dashboard page by navigating to a state where no snippets are available.
- Verified that the empty state is displayed with the new placeholder caption and description.
- Ensured that the "Create New Snippet" button is visible and clickable.
- Validated that the button triggers the snippet creation flow when clicked.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screen
<img width="1512" alt="Screenshot 2025-02-02 at 5 17 04 PM" src="https://github.com/user-attachments/assets/edc5bf70-2ac2-4138-8d6a-6b3681484c4c" />

